### PR TITLE
Add caching for onos-config plugins

### DIFF
--- a/pkg/controller/config/registry/injector.go
+++ b/pkg/controller/config/registry/injector.go
@@ -34,10 +34,6 @@ const (
 	RegistryInjectStatusAnnotation = "registry.config.onosproject.org/inject-status"
 	// RegistryInjectStatusInjected is an annotation value indicating the registry has been injected
 	RegistryInjectStatusInjected = "injected"
-	// RegistryPathAnnotation is an annotation indicating the path at which to mount the registry
-	RegistryPathAnnotation = "registry.config.onosproject.org/path"
-	// CachePathAnnotation is an annotation indicating the path at which to mount the cache
-	CachePathAnnotation = "cache.config.onosproject.org/path"
 	// CompilerVersionAnnotation is an annotation indicating the model API version
 	CompilerVersionAnnotation = "compiler.config.onosproject.org/version"
 	// CompilerTargetAnnotation is an annotation indicating the Go module for which to compile a model
@@ -45,13 +41,15 @@ const (
 )
 
 const (
-	modelPath           = "/etc/onos/models"
-	buildPath           = "/build"
-	registryVolumeName  = "model-registry"
-	cacheVolumeName     = "plugin-cache"
-	defaultGoModTarget  = "github.com/onosproject/onos-config"
-	defaultRegistryPath = "/etc/onos/plugins"
-	defaultCachePath    = "/etc/onos/cache"
+	modelPath          = "/etc/onos/model"
+	buildPath          = "/etc/onos/build"
+	moduleVolumeName   = "plugin-module"
+	registryVolumeName = "model-registry"
+	cacheVolumeName    = "plugin-cache"
+	defaultGoModTarget = "github.com/onosproject/onos-config"
+	registryPath       = "/etc/onos/registry"
+	modulePath         = "/etc/onos/mod"
+	cachePath          = "/etc/onos/plugins"
 )
 
 func newInjector(client client.Client, namespace string) *Injector {
@@ -82,6 +80,9 @@ func (i *Injector) inject(ctx context.Context, pod *corev1.Pod) (bool, error) {
 		return false, nil
 	}
 
+	if err := i.injectInit(pod); err != nil {
+		return true, err
+	}
 	if err := i.injectRegistry(ctx, pod); err != nil {
 		return true, err
 	}
@@ -94,16 +95,71 @@ func (i *Injector) inject(ctx context.Context, pod *corev1.Pod) (bool, error) {
 	return true, nil
 }
 
+func (i *Injector) injectInit(pod *corev1.Pod) error {
+	compilerVersion, err := i.getCompilerVersion(pod)
+	if err != nil {
+		return err
+	}
+	modTarget, err := i.getModTarget(pod)
+	if err != nil {
+		return err
+	}
+	modReplace, err := i.getModReplace(pod)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Injecting module '%s' into Pod '%s/%s'", modTarget, pod.Name, pod.Namespace)
+
+	// Add a module volume to the pod
+	moduleVolume := corev1.Volume{
+		Name: moduleVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, moduleVolume)
+
+	args := []string{
+		"--mod-path",
+		modulePath,
+	}
+
+	if modTarget != "" {
+		args = append(args, "--mod-target", modTarget)
+	}
+
+	if modReplace != "" {
+		args = append(args, "--mod-replace", modReplace)
+	}
+
+	var tags []string
+	if compilerVersion != "" {
+		tags = append(tags, compilerVersion)
+	}
+	image := fmt.Sprintf("onosproject/config-model-init:%s", strings.Join(tags, "-"))
+
+	// Add the compiler init container
+	container := corev1.Container{
+		Name:            "module",
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Args:            args,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      moduleVolumeName,
+				MountPath: modulePath,
+			},
+		},
+	}
+
+	// If the model is present, inject the init container into the pod
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
+	return nil
+}
+
 func (i *Injector) injectRegistry(ctx context.Context, pod *corev1.Pod) error {
 	registryName, err := i.getRegistryName(pod)
-	if err != nil {
-		return err
-	}
-	registryPath, err := i.getRegistryPath(pod)
-	if err != nil {
-		return err
-	}
-	cachePath, err := i.getCachePath(pod)
 	if err != nil {
 		return err
 	}
@@ -160,40 +216,38 @@ func (i *Injector) injectRegistry(ctx context.Context, pod *corev1.Pod) error {
 
 	// Mount the registry volume to existing containers
 	for j, container := range pod.Spec.Containers {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "CONFIG_MODEL_REGISTRY",
-			Value: registryPath,
-		})
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "CONFIG_MODULE_TARGET",
-			Value: modTarget,
-		})
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "CONFIG_MODULE_REPLACE",
-			Value: modReplace,
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      moduleVolumeName,
+			MountPath: modulePath,
 		})
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      registryVolumeName,
 			MountPath: registryPath,
 		})
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      cacheVolumeName,
+			MountPath: cachePath,
+		})
 		pod.Spec.Containers[j] = container
 	}
 
 	args := []string{
+		"--mod-path",
+		modulePath,
 		"--build-path",
 		buildPath,
 		"--registry-path",
 		registryPath,
-		//"--cache-path",
-		//cachePath,
+		"--cache-path",
+		cachePath,
 	}
 
 	if modTarget != "" {
-		args = append(args, "--target", modTarget)
+		args = append(args, "--mod-target", modTarget)
 	}
 
 	if modReplace != "" {
-		args = append(args, "--replace", modReplace)
+		args = append(args, "--mod-replace", modReplace)
 	}
 
 	var tags []string
@@ -209,6 +263,10 @@ func (i *Injector) injectRegistry(ctx context.Context, pod *corev1.Pod) error {
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args:            args,
 		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      moduleVolumeName,
+				MountPath: modulePath,
+			},
 			{
 				Name:      registryVolumeName,
 				MountPath: registryPath,
@@ -244,14 +302,6 @@ func (i *Injector) injectCompilers(ctx context.Context, pod *corev1.Pod) error {
 }
 
 func (i *Injector) injectCompiler(pod *corev1.Pod, model configv1beta1.Model) error {
-	registryPath, err := i.getRegistryPath(pod)
-	if err != nil {
-		return err
-	}
-	cachePath, err := i.getCachePath(pod)
-	if err != nil {
-		return err
-	}
 	compilerVersion, err := i.getCompilerVersion(pod)
 	if err != nil {
 		return err
@@ -288,20 +338,22 @@ func (i *Injector) injectCompiler(pod *corev1.Pod, model configv1beta1.Model) er
 		model.Spec.Plugin.Type,
 		"--version",
 		model.Spec.Plugin.Version,
+		"--mod-path",
+		modulePath,
 		"--build-path",
 		buildPath,
-		"--output-path",
+		"--registry-path",
 		registryPath,
-		//"--cache-path",
-		//cachePath,
+		"--cache-path",
+		cachePath,
 	}
 
 	if modTarget != "" {
-		args = append(args, "--target", modTarget)
+		args = append(args, "--mod-target", modTarget)
 	}
 
 	if modReplace != "" {
-		args = append(args, "--replace", modReplace)
+		args = append(args, "--mod-replace", modReplace)
 	}
 
 	// Add file arguments
@@ -330,6 +382,10 @@ func (i *Injector) injectCompiler(pod *corev1.Pod, model configv1beta1.Model) er
 			{
 				Name:      model.Name,
 				MountPath: modelPath,
+			},
+			{
+				Name:      moduleVolumeName,
+				MountPath: modulePath,
 			},
 			{
 				Name:      registryVolumeName,
@@ -390,23 +446,7 @@ func (i *Injector) getModReplace(pod *corev1.Pod) (string, error) {
 	return compilerTarget, nil
 }
 
-func (i *Injector) getRegistryPath(pod *corev1.Pod) (string, error) {
-	path, ok := pod.Annotations[RegistryPathAnnotation]
-	if !ok {
-		return defaultRegistryPath, nil
-	}
-	return path, nil
-}
-
 func (i *Injector) getRegistryName(pod *corev1.Pod) (string, error) {
 	registry := pod.Annotations[RegistryInjectAnnotation]
 	return registry, nil
-}
-
-func (i *Injector) getCachePath(pod *corev1.Pod) (string, error) {
-	path, ok := pod.Annotations[CachePathAnnotation]
-	if !ok {
-		return defaultCachePath, nil
-	}
-	return path, nil
 }


### PR DESCRIPTION
This PR integrates new features in https://github.com/onosproject/onos-config-model/pull/12 to optimize model/plugin management in onos-config.

The onos-config model controller injects an additional init container into onos-config pods to warm the Go module cache. The _initial_ init container fetches the module info for the target onos-config module to retrieve the checksum. As the init container retrieves the checksum, the Go module and dependencies are written to a module cache volume that's shared across all containers in the pod. The checksum helps ensure plugins are compiled for each unique version of the onos-config binary, and the cache ensures dependencies only have to be downloaded once for all plugins.

The controller also adds a cache volume to onos-config pods which can be configured via the `ModelRegistry` resource. Plugins are read from the cache volume and compiled only in the event of a cache miss, so if the cache is configured with e.g. a NAS or cloud file system volume, each plugin should only need to be compiled once for the entire cluster.

While plugins may be cached in a shared volume, the model registry is still local to each pod. Once the registry for a pod has been started, the operator will register each plugin via the registry API. This is done to allow granular control over the active models while reducing the space needed to store plugins to a single volume.