### PR TITLE
Remove compiler init containers from onos-config injector

### DIFF
--- a/pkg/controller/config/model/reconciler.go
+++ b/pkg/controller/config/model/reconciler.go
@@ -265,7 +265,7 @@ func (r *Reconciler) reconcileCreate(model *v1beta1.Model) (reconcile.Result, er
 	}
 
 	// Update the status for deleted pods
-	for i, podStatus := range model.Status.RegistryStatuses {
+	for _, podStatus := range model.Status.RegistryStatuses {
 		pod := &corev1.Pod{}
 		podName := types.NamespacedName{
 			Namespace: model.Namespace,
@@ -274,8 +274,8 @@ func (r *Reconciler) reconcileCreate(model *v1beta1.Model) (reconcile.Result, er
 		if err := r.client.Get(context.TODO(), podName, pod); err != nil && k8serrors.IsNotFound(err) {
 			log.Debugf("Forgetting Model '%s/%s' status for Pod '%s'", model.Namespace, model.Name, pod.Name)
 			podStatuses := make([]v1beta1.RegistryStatus, 0, len(model.Status.RegistryStatuses)-1)
-			for j, s := range model.Status.RegistryStatuses {
-				if i != j {
+			for _, s := range model.Status.RegistryStatuses {
+				if s.PodName != pod.Name {
 					podStatuses = append(podStatuses, s)
 				}
 			}

--- a/pkg/controller/config/model/reconciler.go
+++ b/pkg/controller/config/model/reconciler.go
@@ -28,13 +28,11 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -122,39 +120,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *Reconciler) reconcileCreate(model *v1beta1.Model) (reconcile.Result, error) {
-	// Create a ConfigMap to store the modules
-	cm := &corev1.ConfigMap{}
-	cmName := types.NamespacedName{
-		Name:      model.Name,
-		Namespace: model.Namespace,
-	}
-	if err := r.client.Get(context.Background(), cmName, cm); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-
-		log.Debugf("Creating ConfigMap '%s' for Model '%s/%s'", model.Name, model.Namespace, model.Name)
-		files := make(map[string]string)
-		for name, data := range model.Spec.Files {
-			files[util.NormalizeFileName(name)] = data
-		}
-		cm = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      model.Name,
-				Namespace: model.Namespace,
-			},
-			Data: files,
-		}
-		if err := controllerutil.SetOwnerReference(model, cm, r.scheme); err != nil {
-			log.Warnf("Failed to set ConfigMap '%s' owner Model '%s/%s': %s", model.Name, model.Namespace, model.Name, err)
-			return reconcile.Result{}, err
-		}
-		if err := r.client.Create(context.Background(), cm); err != nil {
-			log.Warnf("Failed to create ConfigMap '%s' for Model '%s/%s': %s", model.Name, model.Namespace, model.Name, err)
-			return reconcile.Result{}, err
-		}
-	}
-
 	// If the model does not define a plugin configuration, it doesn't need to be injected into any pods
 	if model.Spec.Plugin == nil {
 		return reconcile.Result{}, nil

--- a/pkg/controller/config/registry/injector.go
+++ b/pkg/controller/config/registry/injector.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"fmt"
 	configv1beta1 "github.com/onosproject/onos-operator/pkg/apis/config/v1beta1"
-	"github.com/onosproject/onos-operator/pkg/controller/config/util"
 	"github.com/rogpeppe/go-internal/module"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 )
@@ -42,7 +40,6 @@ const (
 )
 
 const (
-	modelPath          = "/etc/onos/model"
 	buildPath          = "/etc/onos/build"
 	moduleVolumeName   = "plugin-module"
 	registryVolumeName = "model-registry"
@@ -83,95 +80,13 @@ func (i *Injector) inject(ctx context.Context, pod *corev1.Pod) (bool, error) {
 		return false, nil
 	}
 
-	if err := i.injectInit(pod); err != nil {
-		return true, err
-	}
 	if err := i.injectRegistry(ctx, pod); err != nil {
-		return true, err
-	}
-	if err := i.injectCompilers(ctx, pod); err != nil {
 		return true, err
 	}
 
 	// Set the registry injection status to injected
 	pod.Annotations[RegistryInjectStatusAnnotation] = RegistryInjectStatusInjected
 	return true, nil
-}
-
-func (i *Injector) injectInit(pod *corev1.Pod) error {
-	compilerVersion, err := i.getCompilerVersion(pod)
-	if err != nil {
-		return err
-	}
-	modTarget, err := i.getModTarget(pod)
-	if err != nil {
-		return err
-	}
-	modReplace, err := i.getModReplace(pod)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Injecting module '%s' into Pod '%s/%s'", modTarget, pod.Name, pod.Namespace)
-
-	// Add a module volume to the pod
-	moduleVolume := corev1.Volume{
-		Name: moduleVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	}
-	pod.Spec.Volumes = append(pod.Spec.Volumes, moduleVolume)
-
-	// Add a module cache volume to the pod
-	goCacheVolume := corev1.Volume{
-		Name: goCacheVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	}
-	pod.Spec.Volumes = append(pod.Spec.Volumes, goCacheVolume)
-
-	args := []string{
-		"--mod-path",
-		modulePath,
-	}
-
-	if modTarget != "" {
-		args = append(args, "--mod-target", modTarget)
-	}
-
-	if modReplace != "" {
-		args = append(args, "--mod-replace", modReplace)
-	}
-
-	var tags []string
-	if compilerVersion != "" {
-		tags = append(tags, compilerVersion)
-	}
-	image := fmt.Sprintf("onosproject/config-model-init:%s", strings.Join(tags, "-"))
-
-	// Add the compiler init container
-	container := corev1.Container{
-		Name:            "module",
-		Image:           image,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args:            args,
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      moduleVolumeName,
-				MountPath: modulePath,
-			},
-			{
-				Name:      goCacheVolumeName,
-				MountPath: goCachePath,
-			},
-		},
-	}
-
-	// If the model is present, inject the init container into the pod
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
-	return nil
 }
 
 func (i *Injector) injectRegistry(ctx context.Context, pod *corev1.Pod) error {
@@ -308,124 +223,6 @@ func (i *Injector) injectRegistry(ctx context.Context, pod *corev1.Pod) error {
 
 	// If the model is present, inject the init container into the pod
 	pod.Spec.Containers = append(pod.Spec.Containers, container)
-	return nil
-}
-
-func (i *Injector) injectCompilers(ctx context.Context, pod *corev1.Pod) error {
-	// Load existing models via init containers
-	modelList := &configv1beta1.ModelList{}
-	modelListOpts := &client.ListOptions{
-		Namespace: i.namespace,
-	}
-	if err := i.client.List(ctx, modelList, modelListOpts); err != nil {
-		return err
-	}
-
-	for _, model := range modelList.Items {
-		if err := i.injectCompiler(pod, model); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (i *Injector) injectCompiler(pod *corev1.Pod, model configv1beta1.Model) error {
-	compilerVersion, err := i.getCompilerVersion(pod)
-	if err != nil {
-		return err
-	}
-	modTarget, err := i.getModTarget(pod)
-	if err != nil {
-		return err
-	}
-	modReplace, err := i.getModReplace(pod)
-	if err != nil {
-		return err
-	}
-
-	if model.Spec.Plugin == nil {
-		return nil
-	}
-
-	log.Infof("Injecting model '%s' into Pod '%s/%s'", model.Name, pod.Name, pod.Namespace)
-
-	// Add the model volume to the pod
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: model.Name,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: model.Name,
-				},
-			},
-		},
-	})
-
-	args := []string{
-		"--name",
-		model.Spec.Plugin.Type,
-		"--version",
-		model.Spec.Plugin.Version,
-		"--mod-path",
-		modulePath,
-		"--build-path",
-		buildPath,
-		"--cache-path",
-		pluginsPath,
-	}
-
-	if modTarget != "" {
-		args = append(args, "--mod-target", modTarget)
-	}
-
-	if modReplace != "" {
-		args = append(args, "--mod-replace", modReplace)
-	}
-
-	// Add file arguments
-	for name := range model.Spec.Files {
-		args = append(args, "--file", filepath.Join(modelPath, util.NormalizeFileName(name)))
-	}
-
-	// Add module arguments
-	for _, module := range model.Spec.Modules {
-		args = append(args, "--module", fmt.Sprintf("%s@%s=%s", module.Name, module.Revision, util.NormalizeFileName(module.File)))
-	}
-
-	var tags []string
-	if compilerVersion != "" {
-		tags = append(tags, compilerVersion)
-	}
-	image := fmt.Sprintf("onosproject/config-model-compiler:%s", strings.Join(tags, "-"))
-
-	// Add the compiler init container
-	container := corev1.Container{
-		Name:            fmt.Sprintf("%s-%s-compiler", strings.ToLower(model.Spec.Plugin.Type), strings.ReplaceAll(model.Spec.Plugin.Version, ".", "-")),
-		Image:           image,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args:            args,
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      model.Name,
-				MountPath: modelPath,
-			},
-			{
-				Name:      moduleVolumeName,
-				MountPath: modulePath,
-			},
-			{
-				Name:      goCacheVolumeName,
-				MountPath: goCachePath,
-			},
-			{
-				Name:      pluginsVolumeName,
-				MountPath: pluginsPath,
-			},
-		},
-	}
-
-	// If the model is present, inject the init container into the pod
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
 	return nil
 }
 


### PR DESCRIPTION
This PR discontinues the use of the compiler in init containers. Kubernetes runs init containers in serial, and each container has to initialize the Go compiler to some extent. This is too inefficient. The registry sidecar is instead responsible for compiling plugins.