### PR TITLE
Remove Go cache volume from onos-config pods

### DIFF
--- a/deploy/onos-operator.yaml
+++ b/deploy/onos-operator.yaml
@@ -354,7 +354,7 @@ spec:
       serviceAccountName: onos-operator
       initContainers:
       - name: init-certs
-        image: onosproject/config-operator-init:v0.4.0
+        image: onosproject/config-operator-init:latest
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -384,7 +384,7 @@ spec:
           mountPath: /etc/webhook/certs
       containers:
       - name: controller
-        image: onosproject/config-operator:v0.4.0
+        image: onosproject/config-operator:latest
         ports:
         - containerPort: 60000
           name: metrics
@@ -490,7 +490,7 @@ spec:
       serviceAccountName: onos-operator
       containers:
       - name: controller
-        image: onosproject/topo-operator:v0.4.0
+        image: onosproject/topo-operator:latest
         ports:
         - containerPort: 60000
           name: metrics


### PR DESCRIPTION
Remove the Go cache volume from onos-config pods to avoid overwriting the pre-built cache.